### PR TITLE
Fix $overviewtext for german amazon page and remove some tabs at the end of lines

### DIFF
--- a/amazon.rb
+++ b/amazon.rb
@@ -54,7 +54,7 @@ case country
 		$accounttext = 'Mein Konto'
 		$orderstext = 'Meine Bestellungen'
 		$currency = 'EUR '
-		$overviewtext = 'Übersicht anzeigen'
+		$overviewtext = 'Bestellübersicht drucken'
 		$pricedelimiter = ','
 		$thousandseperator = '.'
 		$nexttext = 'Weiter »'


### PR DESCRIPTION
The text for the `$overviewtext` has been changed. I've also removed some tabs at the end of lines that are not required.
